### PR TITLE
cancel timer appropriately

### DIFF
--- a/ShotBlocker/ShotBlocker.m
+++ b/ShotBlocker/ShotBlocker.m
@@ -81,6 +81,7 @@ static NSTimeInterval const kShotBlockerUpdateInterval = 1.0;
   if (_timer) {
     dispatch_suspend(_timer);
     dispatch_resume(_timer);
+    dispatch_source_cancel(_timer);
     _timer = nil;
   }
   self.groupCounts = nil;


### PR DESCRIPTION
If not doing this, timer event will fire after stopDetectingScreenshots call
